### PR TITLE
Implement resize on kit and core

### DIFF
--- a/examples/kit.rs
+++ b/examples/kit.rs
@@ -127,6 +127,9 @@ fn main() {
                     WindowEvent::CloseRequested => {
                         running = false;
                     }
+                    WindowEvent::Resized(size) => {
+                        kit.resize(size.to_physical(window.get_hidpi_factor()));
+                    }
                     _ => {}
                 }
             }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -185,6 +185,9 @@ fn main() {
                     WindowEvent::CloseRequested => {
                         running = false;
                     }
+                    WindowEvent::Resized(size) => {
+                        ctx.resize(size.to_physical(window.get_hidpi_factor()));
+                    }
                     _ => {}
                 }
             }

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -90,6 +90,9 @@ fn main() {
                     WindowEvent::CloseRequested => {
                         running = false;
                     }
+                    WindowEvent::Resized(size) => {
+                        kit.resize(size.to_physical(window.get_hidpi_factor()));
+                    }
                     _ => {}
                 }
             }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -321,6 +321,7 @@ impl<'a> Frame<'a> {
 
 pub struct Context {
     device: wgpu::Device,
+    surface: wgpu::Surface,
     swap_chain: wgpu::SwapChain,
     commands: Vec<Command>,
 }
@@ -344,20 +345,15 @@ impl Context {
             .get_inner_size()
             .unwrap()
             .to_physical(window.get_hidpi_factor());
-        let swap_chain = device.create_swap_chain(
-            &surface,
-            &wgpu::SwapChainDescriptor {
-                usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
-                format: wgpu::TextureFormat::Bgra8Unorm,
-                width: size.width as u32,
-                height: size.height as u32,
-            },
-        );
+        let swap_chain_desc =
+            swap_chain_descriptor(size.width.round() as u32, size.height.round() as u32);
+        let swap_chain = device.create_swap_chain(&surface, &swap_chain_desc);
 
         let commands = Vec::new();
 
         Self {
             device,
+            surface,
             swap_chain,
             commands,
         }
@@ -671,5 +667,25 @@ impl Context {
             vertex_layout,
             wgpu,
         }
+    }
+
+    pub fn resize(&mut self, physical: wgpu::winit::dpi::PhysicalSize) {
+        let swap_chain_descriptor = swap_chain_descriptor(
+            physical.width.round() as u32,
+            physical.height.round() as u32,
+        );
+
+        self.swap_chain = self
+            .device
+            .create_swap_chain(&self.surface, &swap_chain_descriptor);
+    }
+}
+
+fn swap_chain_descriptor(width: u32, height: u32) -> wgpu::SwapChainDescriptor {
+    wgpu::SwapChainDescriptor {
+        usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+        format: wgpu::TextureFormat::Bgra8Unorm,
+        width,
+        height,
     }
 }

--- a/src/kit/mod.rs
+++ b/src/kit/mod.rs
@@ -261,7 +261,7 @@ impl Kit {
     pub fn resize(&mut self, physical: PhysicalSize) {
         self.ctx.resize(physical);
 
-        let ortho = Ortho::<f32> {
+        self.ortho = Ortho::<f32> {
             left: 0.0,
             right: physical.width as f32,
             bottom: 0.0,
@@ -269,18 +269,6 @@ impl Kit {
             near: -1.0,
             far: 1.0,
         };
-
-        let mvp_buf = Rc::new(self.ctx.create_uniform_buffer(Uniforms {
-            ortho: ortho.into(),
-            transform: self.transform,
-        }));
-        let mvp_binding = self.ctx.create_binding(
-            &self.pipeline.layout.sets[0],
-            &[core::Uniform::Buffer(&mvp_buf)],
-        );
-
-        self.mvp_buf = mvp_buf;
-        self.mvp_binding = mvp_binding;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/kit/mod.rs
+++ b/src/kit/mod.rs
@@ -4,6 +4,7 @@ use crate::core::{
     Binding, BindingType, Context, Sampler, Set, ShaderStage, Texture, VertexLayout,
 };
 
+use wgpu::winit::dpi::PhysicalSize;
 use wgpu::winit::Window;
 
 use cgmath::prelude::*;
@@ -257,6 +258,31 @@ impl Kit {
         frame.commit();
     }
 
+    pub fn resize(&mut self, physical: PhysicalSize) {
+        self.ctx.resize(physical);
+
+        let ortho = Ortho::<f32> {
+            left: 0.0,
+            right: physical.width as f32,
+            bottom: 0.0,
+            top: physical.height as f32,
+            near: -1.0,
+            far: 1.0,
+        };
+
+        let mvp_buf = Rc::new(self.ctx.create_uniform_buffer(Uniforms {
+            ortho: ortho.into(),
+            transform: self.transform,
+        }));
+        let mvp_binding = self.ctx.create_binding(
+            &self.pipeline.layout.sets[0],
+            &[core::Uniform::Buffer(&mvp_buf)],
+        );
+
+        self.mvp_buf = mvp_buf;
+        self.mvp_binding = mvp_binding;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
 
     fn _frame(&mut self) -> Frame {
@@ -273,11 +299,6 @@ impl Kit {
             pipeline: &self.pipeline,
             mvp_binding: &self.mvp_binding,
         }
-    }
-
-    #[allow(dead_code)]
-    fn resize(&mut self, _w: u32, _h: u32) {
-        unimplemented!();
     }
 }
 


### PR DESCRIPTION
~~First attempt in getting resize to work. Basically assuming anything that depends on the window size needs to be updated or newly created. It solves the crashes observed before, but shows some maybe unintended scaling.~~

Support resizing by recreating resources that depend on the physical window size.

* create new swapchain
* update kits ortho