### PR TITLE
Brief instructions for rebuilding the SPV shaders on MacOS / Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [examples/helloworld.rs](examples/helloworld.rs) for a simple usage example.
 Rebuilding the shaders
 ----------------------
 
-To manually rebuild the shaders on MacOS and Linux, run the following:
+To rebuild the shaders run the following:
 
 ```bash
 glslc -c -Werror --target-env=vulkan ./examples/data/framebuffer.vert -o ./examples/data/framebuffer.vert.spv

--- a/README.md
+++ b/README.md
@@ -51,14 +51,12 @@ Rebuilding the shaders
 ----------------------
 To rebuild the shaders run the following:
 
-```bash
-glslc -c -Werror --target-env=vulkan ./examples/data/framebuffer.vert -o ./examples/data/framebuffer.vert.spv
-glslc -c -Werror --target-env=vulkan ./examples/data/framebuffer.frag -o ./examples/data/framebuffer.frag.spv
-glslc -c -Werror --target-env=vulkan ./src/kit/data/shape.frag        -o ./src/kit/data/shape.frag.spv
-glslc -c -Werror --target-env=vulkan ./src/kit/data/sprite.frag       -o ./src/kit/data/sprite.frag.spv
-glslc -c -Werror --target-env=vulkan ./src/kit/data/shape.vert        -o ./src/kit/data/shape.vert.spv
-glslc -c -Werror --target-env=vulkan ./src/kit/data/sprite.vert       -o ./src/kit/data/sprite.vert.spv
-```
+    glslc -c -Werror --target-env=vulkan ./examples/data/framebuffer.vert -o ./examples/data/framebuffer.vert.spv
+    glslc -c -Werror --target-env=vulkan ./examples/data/framebuffer.frag -o ./examples/data/framebuffer.frag.spv
+    glslc -c -Werror --target-env=vulkan ./src/kit/data/shape.frag        -o ./src/kit/data/shape.frag.spv
+    glslc -c -Werror --target-env=vulkan ./src/kit/data/sprite.frag       -o ./src/kit/data/sprite.frag.spv
+    glslc -c -Werror --target-env=vulkan ./src/kit/data/shape.vert        -o ./src/kit/data/shape.vert.spv
+    glslc -c -Werror --target-env=vulkan ./src/kit/data/sprite.vert       -o ./src/kit/data/sprite.vert.spv
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ See [examples/helloworld.rs](examples/helloworld.rs) for a simple usage example.
 
 Rebuilding the shaders
 ----------------------
-
 To rebuild the shaders run the following:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ Usage
 -----
 See [examples/helloworld.rs](examples/helloworld.rs) for a simple usage example.
 
+
+Rebuilding the shaders
+----------------------
+
+To manually rebuild the shaders on MacOS and Linux, run the following:
+
+```bash
+glslc -c -Werror --target-env=vulkan ./examples/data/framebuffer.vert -o ./examples/data/framebuffer.vert.spv
+glslc -c -Werror --target-env=vulkan ./examples/data/framebuffer.frag -o ./examples/data/framebuffer.frag.spv
+glslc -c -Werror --target-env=vulkan ./src/kit/data/shape.frag        -o ./src/kit/data/shape.frag.spv
+glslc -c -Werror --target-env=vulkan ./src/kit/data/sprite.frag       -o ./src/kit/data/sprite.frag.spv
+glslc -c -Werror --target-env=vulkan ./src/kit/data/shape.vert        -o ./src/kit/data/shape.vert.spv
+glslc -c -Werror --target-env=vulkan ./src/kit/data/sprite.vert       -o ./src/kit/data/sprite.vert.spv
+```
+
 Support
 -------
 If you find this project useful, consider supporting it by sending ₿ (Bitcoin) to


### PR DESCRIPTION
As per issue #11, this branch add a list of commands to rebuild the shaders for rgx manually on MacOS / Linux environments.