### PR TITLE
Adding all-features for docs.rs configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT"
 edition = "2018"
 keywords = ["graphics", "gamedev", "wgpu", "2d"]
 
+
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 name = "rgx"
 


### PR DESCRIPTION
I reported #20 last night, and originally couldn't find the documentation on how to make it work. I found it this morning: https://docs.rs/about

Hopefully, this should upon the next crate publish allow the core module to be documented on docs.rs again. I'm not sure how to test this without actually publishing the crate, though.