### PR TITLE
Fix compilation errors in current Rust/Clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ wgpu = { version = "0.4.0", optional = true }
 cgmath = { version = "0.17.0", optional = true }
 num-traits = "0.2.8"
 raw-window-handle = { version = "0.3", optional = true }
-approx = "0.3"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 edition = "2018"
 keywords = ["graphics", "gamedev", "wgpu", "2d"]
 
-
 [package.metadata.docs.rs]
 all-features = true
 
@@ -26,6 +25,7 @@ wgpu = { version = "0.4.0", optional = true }
 cgmath = { version = "0.17.0", optional = true }
 num-traits = "0.2.8"
 raw-window-handle = { version = "0.3", optional = true }
+approx = "0.3"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -11,10 +11,12 @@ use rgx::kit::ZDepth;
 
 fn bench_triangulate_circle() {
     Shape::Circle(
-        Point2::new(0., 0.),
+        Circle {
+            position: Point2::new(0., 0.),
+            radius: 1.,
+            sides: 64,
+        },
         ZDepth::default(),
-        1.,
-        64,
         Stroke::new(1., Rgba::WHITE),
         Fill::Solid(Rgba::WHITE),
     )
@@ -33,11 +35,9 @@ fn bench_triangulate_rectangle() {
 }
 
 fn benchmark(c: &mut Criterion) {
-    c.bench_function("triangulate circle", |b| {
-        b.iter(|| bench_triangulate_circle())
-    });
+    c.bench_function("triangulate circle", |b| b.iter(bench_triangulate_circle));
     c.bench_function("triangulate rectangle", |b| {
-        b.iter(|| bench_triangulate_rectangle())
+        b.iter(bench_triangulate_rectangle)
     });
 }
 

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -24,16 +24,17 @@ fn main() -> Result<(), std::io::Error> {
     // Setup renderer
     ///////////////////////////////////////////////////////////////////////////
 
-    let mut r = Renderer::new(&window)?;
+    let mut renderer = Renderer::new(&window)?;
     let mut win = window.inner_size();
 
-    let pip: kit::shape2d::Pipeline = r.pipeline(Blending::default());
+    let pip: kit::shape2d::Pipeline = renderer.pipeline(Blending::default());
 
     ///////////////////////////////////////////////////////////////////////////
     // Render loop
     ///////////////////////////////////////////////////////////////////////////
 
-    let mut textures = r.swap_chain(win.width as u32, win.height as u32, PresentMode::default());
+    let mut textures =
+        renderer.swap_chain(win.width as u32, win.height as u32, PresentMode::default());
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::NewEvents(StartCause::Init) => {
@@ -63,7 +64,7 @@ fn main() -> Result<(), std::io::Error> {
 
                 let (w, h) = (win.width as u32, win.height as u32);
 
-                textures = r.swap_chain(w, h, PresentMode::default());
+                textures = renderer.swap_chain(w, h, PresentMode::default());
 
                 *control_flow = ControlFlow::Poll;
             }
@@ -169,17 +170,17 @@ fn main() -> Result<(), std::io::Error> {
                 );
             }
 
-            let buffer = batch.finish(&r);
+            let buffer = batch.finish(&renderer);
 
             ///////////////////////////////////////////////////////////////////////////
             // Create frame
             ///////////////////////////////////////////////////////////////////////////
 
-            let mut frame = r.frame();
+            let mut frame = renderer.frame();
 
             let out = textures.next();
 
-            r.update_pipeline(
+            renderer.update_pipeline(
                 &pip,
                 kit::ortho(out.width, out.height, Default::default()),
                 &mut frame,
@@ -195,7 +196,7 @@ fn main() -> Result<(), std::io::Error> {
                 pass.set_pipeline(&pip);
                 pass.draw_buffer(&buffer);
             }
-            r.present(frame);
+            renderer.present(frame);
 
             *control_flow = ControlFlow::Poll;
             window.request_redraw();

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -21,7 +21,7 @@ use winit::{
 fn main() -> Result<(), std::io::Error> {
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop).unwrap();
-    let mut size = window.inner_size();
+    let size = window.inner_size();
 
     // Setup renderer
     let mut renderer = Renderer::new(&window)?;
@@ -82,10 +82,8 @@ fn main() -> Result<(), std::io::Error> {
                 m.1 = position.y as f32;
             }
             WindowEvent::Resized(s) => {
-                size = s;
-
                 let mut shared = shared_size.lock().unwrap();
-                *shared = size;
+                *shared = s;
             }
             WindowEvent::KeyboardInput {
                 input:

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,8 +1,8 @@
 pub mod transform;
 
-use std::ops::Range;
-
+use approx::relative_eq;
 use raw_window_handle::HasRawWindowHandle;
+use std::ops::Range;
 
 // TODO: These shouldn't be re-exported from here.
 pub use crate::color::{Bgra8, Rgba, Rgba8};
@@ -371,14 +371,12 @@ impl Texture {
     }
 
     fn blit(&self, src: Rect<f32>, dst: Rect<f32>, encoder: &mut wgpu::CommandEncoder) {
-        assert_eq!(
-            src.width(),
-            dst.width(),
+        assert!(
+            relative_eq!(src.width(), dst.width()),
             "source and destination rectangles must be of the same size"
         );
-        assert_eq!(
-            src.height(),
-            dst.height(),
+        assert!(
+            relative_eq!(src.height(), dst.height()),
             "source and destination rectangles must be of the same size"
         );
 
@@ -411,6 +409,7 @@ impl Texture {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn copy(
         texture: &wgpu::Texture,
         w: u32,
@@ -982,6 +981,7 @@ impl SwapChain {
     ///
     /// When the [`SwapChainTexture`] returned by this method is dropped, the
     /// swapchain will present the texture to the associated [`Renderer`].
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> SwapChainTexture {
         SwapChainTexture {
             depth: &self.depth,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,5 @@
 pub mod transform;
 
-use approx::relative_eq;
 use raw_window_handle::HasRawWindowHandle;
 use std::ops::Range;
 
@@ -372,11 +371,11 @@ impl Texture {
 
     fn blit(&self, src: Rect<f32>, dst: Rect<f32>, encoder: &mut wgpu::CommandEncoder) {
         assert!(
-            relative_eq!(src.width(), dst.width()),
+            (src.width() - dst.width()).abs() <= f32::EPSILON,
             "source and destination rectangles must be of the same size"
         );
         assert!(
-            relative_eq!(src.height(), dst.height()),
+            (src.height() - dst.height()).abs() <= f32::EPSILON,
             "source and destination rectangles must be of the same size"
         );
 
@@ -409,7 +408,6 @@ impl Texture {
         );
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn copy(
         texture: &wgpu::Texture,
         w: u32,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -979,7 +979,6 @@ impl SwapChain {
     ///
     /// When the [`SwapChainTexture`] returned by this method is dropped, the
     /// swapchain will present the texture to the associated [`Renderer`].
-    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> SwapChainTexture {
         SwapChainTexture {
             depth: &self.depth,

--- a/src/core/transform.rs
+++ b/src/core/transform.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::math::Matrix4;
 
+#[cfg(feature = "cgmath")]
+use cgmath::SquareMatrix;
+
 #[derive(Copy, Clone)]
 pub struct AlignedBuffer {
     // TODO: Make this generic when rust-lang#43408 is fixed.

--- a/src/kit/shape2d/mod.rs
+++ b/src/kit/shape2d/mod.rs
@@ -420,14 +420,14 @@ pub struct Circle {
 // Batch
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Batch {
     items: Vec<Shape>,
 }
 
 impl Batch {
     pub fn new() -> Self {
-        Self { items: Vec::new() }
+        Self::default()
     }
 
     pub fn singleton(shape: Shape) -> Self {

--- a/src/kit/shape2d/mod.rs
+++ b/src/kit/shape2d/mod.rs
@@ -125,7 +125,9 @@ pub enum Shape {
 }
 
 impl Shape {
-    pub fn circle(position: Point2<f32>, radius: f32, sides: u32) -> Self {
+    pub fn circle<P: Into<Point2<f32>>>(position: P, radius: f32, sides: u32) -> Self {
+        let position = position.into();
+
         Self::Circle(
             Circle {
                 position,
@@ -409,9 +411,9 @@ impl std::ops::Add<Vector2<f32>> for Line {
 
 #[derive(Copy, Clone, Debug)]
 pub struct Circle {
-    position: Point2<f32>,
-    radius: f32,
-    sides: u32,
+    pub position: Point2<f32>,
+    pub radius: f32,
+    pub sides: u32,
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/kit/sprite2d/mod.rs
+++ b/src/kit/sprite2d/mod.rs
@@ -23,6 +23,7 @@ pub struct Vertex {
 }
 
 impl Vertex {
+    #[allow(clippy::many_single_char_names)]
     fn new(x: f32, y: f32, z: f32, u: f32, v: f32, color: Rgba8, opacity: f32) -> Self {
         Self {
             position: Vector3::new(x, y, z),
@@ -104,6 +105,7 @@ impl Batch {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn singleton(
         w: u32,
         h: u32,
@@ -199,7 +201,7 @@ impl Batch {
 
     pub fn offset(&mut self, x: f32, y: f32) {
         for sprite in self.items.iter_mut() {
-            sprite.dst = sprite.dst + Vector2::new(x, y);
+            sprite.dst += Vector2::new(x, y);
         }
     }
 

--- a/src/kit/sprite2d/mod.rs
+++ b/src/kit/sprite2d/mod.rs
@@ -23,7 +23,6 @@ pub struct Vertex {
 }
 
 impl Vertex {
-    #[allow(clippy::many_single_char_names)]
     fn new(x: f32, y: f32, z: f32, u: f32, v: f32, color: Rgba8, opacity: f32) -> Self {
         Self {
             position: Vector3::new(x, y, z),

--- a/src/kit/sprite2d/mod.rs
+++ b/src/kit/sprite2d/mod.rs
@@ -105,7 +105,6 @@ impl Batch {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn singleton(
         w: u32,
         h: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![allow(clippy::too_many_arguments)]
+#![allow(clippy::should_implement_trait)]
 
 pub mod color;
 pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::too_many_arguments)]
 
 pub mod color;
 pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
-#![allow(clippy::too_many_arguments)]
+#![allow(clippy::many_single_char_names)]
 #![allow(clippy::should_implement_trait)]
+#![allow(clippy::too_many_arguments)]
 
 pub mod color;
 pub mod error;


### PR DESCRIPTION
This PR aims to get the master branch in a state that is ready for active development again. The last few PRs I've disabled the clippy deny all statement to fix the issues at hand, but I wanted to start working on getting rgx onto current versions of wgpu so that whenever the OpenGL support lands, rgx can be run in WebAssembly as well.